### PR TITLE
Http PATCH method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    httmultiparty (0.3.16)
+    httmultiparty (0.4.0)
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
@@ -11,7 +11,7 @@ GEM
   specs:
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
-    httparty (0.12.0)
+    httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -139,6 +139,7 @@ module HTTMultiParty
     end
 
     def patch(path, options={})
+      p "PATCH #{path} \n#{options}"
       method = Net::HTTP::Patch
       options[:body] ||= options.delete(:query)
       if hash_contains_files?(options[:body])

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -25,7 +25,7 @@ module HTTMultiParty
       HTTMultiParty.flatten_params(params).map do |(k,v)|
         if file_present?(params)
           v = prepare_value!(v,detect_mime_type)
-          p "Value size #{v.size} read #{v.read}"
+          p "Value size #{v.size} read #{v.read}" if v.respond_to?(:read)
           [k, v]
         else
           "#{k}=#{v}"

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -139,13 +139,11 @@ module HTTMultiParty
     end
 
     def patch(path, options={})
-      p "PATCH #{path} #{options}"
       method = Net::HTTP::Patch
       options[:body] ||= options.delete(:query)
       if hash_contains_files?(options[:body]) || options[:multipart]
         method = MultipartPatch
         options[:query_string_normalizer] = HTTMultiParty.query_string_normalizer(options)
-        p "Options #{options}"
       end
       perform_request method, path, options
     end

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -139,12 +139,13 @@ module HTTMultiParty
     end
 
     def patch(path, options={})
-      p "PATCH #{path} \n#{options}"
+      p "PATCH #{path} #{options}"
       method = Net::HTTP::Patch
       options[:body] ||= options.delete(:query)
       if hash_contains_files?(options[:body])
         method = MultipartPatch
         options[:query_string_normalizer] = HTTMultiParty.query_string_normalizer(options)
+        p "Options #{options}"
       end
       perform_request method, path, options
     end

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -142,7 +142,7 @@ module HTTMultiParty
       p "PATCH #{path} #{options}"
       method = Net::HTTP::Patch
       options[:body] ||= options.delete(:query)
-      if hash_contains_files?(options[:body])
+      if hash_contains_files?(options[:body]) || options[:multipart]
         method = MultipartPatch
         options[:query_string_normalizer] = HTTMultiParty.query_string_normalizer(options)
         p "Options #{options}"

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -25,6 +25,7 @@ module HTTMultiParty
       HTTMultiParty.flatten_params(params).map do |(k,v)|
         if file_present?(params)
           v = prepare_value!(v,detect_mime_type)
+          p "Value size #{v.size} read #{v.read}"
           [k, v]
         else
           "#{k}=#{v}"

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -24,8 +24,7 @@ module HTTMultiParty
     Proc.new do |params|
       HTTMultiParty.flatten_params(params).map do |(k,v)|
         if file_present?(params)
-          v = prepare_value!(v,detect_mime_type)
-          p "Value size #{v.size} read #{v.read}" if v.respond_to?(:read)
+          v = prepare_value!(v,detect_mime_type)          
           [k, v]
         else
           "#{k}=#{v}"

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -68,6 +68,10 @@ module HTTMultiParty
     Basement.put(*args)
   end
 
+  def self.patch(*args)
+    Basement.patch(*args)
+  end
+
   def self.delete(*args)
     Basement.delete(*args)
   end
@@ -134,6 +138,16 @@ module HTTMultiParty
       perform_request method, path, options
     end
 
+    def patch(path, options={})
+      method = Net::HTTP::Patch
+      options[:body] ||= options.delete(:query)
+      if hash_contains_files?(options[:body])
+        method = MultipartPatch
+        options[:query_string_normalizer] = HTTMultiParty.query_string_normalizer(options)
+      end
+      perform_request method, path, options
+    end
+
     private
 
     def hash_contains_files?(hash)
@@ -150,3 +164,4 @@ require 'httmultiparty/version'
 require 'httmultiparty/multipartable'
 require 'httmultiparty/multipart_post'
 require 'httmultiparty/multipart_put'
+require 'httmultiparty/multipart_patch'

--- a/lib/httmultiparty.rb
+++ b/lib/httmultiparty.rb
@@ -23,7 +23,7 @@ module HTTMultiParty
     detect_mime_type = options.fetch(:detect_mime_type, false)
     Proc.new do |params|
       HTTMultiParty.flatten_params(params).map do |(k,v)|
-        if file_present?(params)
+        if file_present?(params) || options[:multipart]
           v = prepare_value!(v,detect_mime_type)          
           [k, v]
         else

--- a/lib/httmultiparty/multipart_patch.rb
+++ b/lib/httmultiparty/multipart_patch.rb
@@ -1,0 +1,5 @@
+class HTTMultiParty::MultipartPatch < Net::HTTP::Patch
+  include HTTMultiParty::Multipartable
+end
+
+HTTParty::Request::SupportedHTTPMethods << HTTMultiParty::MultipartPatch

--- a/lib/httmultiparty/version.rb
+++ b/lib/httmultiparty/version.rb
@@ -1,3 +1,3 @@
 module HTTMultiParty
-  VERSION = '0.3.16'
+  VERSION = '0.4.0'
 end

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -98,6 +98,55 @@ describe HTTMultiParty do
     end
   end
 
+  describe '#patch' do
+    it "should respond to patch" do
+      klass.should respond_to :post
+    end
+
+    it "should setup new request with Net::HTTP::Patch" do
+      HTTParty::Request.should_receive(:new) \
+        .with(Net::HTTP::Patch, anything, anything) \
+        .and_return(mock("mock response", :perform => nil))
+      klass.patch('http://example.com/', {})
+    end
+
+    describe 'when :query contains a file' do
+      let(:query) { {:somefile => somefile } }
+
+      it "should setup new request with Net::HTTP::Patch::Multipart" do
+        HTTParty::Request.should_receive(:new) \
+          .with(HTTMultiParty::MultipartPatch, anything, anything) \
+          .and_return(mock("mock response", :perform => nil))
+        klass.patch('http://example.com/', :query => query)
+      end
+    end
+
+    describe 'when :body contains a file' do
+      let(:body) { {:somefile => somefile } }
+
+      it "should setup new request with Net::HTTP::Patch::Multipart" do
+        HTTParty::Request.should_receive(:new) \
+          .with(HTTMultiParty::MultipartPatch, anything, anything) \
+          .and_return(mock("mock response", :perform => nil))
+        klass.patch('http://example.com/', :body => body)
+      end
+    end
+
+    describe 'with default_params' do
+      let(:body) { { somefile: somefile } }
+
+      it 'should include default_params also' do
+        klass.tap do |c|
+          c.instance_eval { default_params(token: 'fake') }
+        end
+
+        FakeWeb.register_uri(:patch, 'http://example.com?token=fake', body: 'hello world')
+
+        klass.patch('http://example.com', body: body)
+      end
+    end
+  end
+
   describe "#file_to_upload_io" do
     it "should get the physical name of a file" do
       HTTMultiParty.file_to_upload_io(somefile)\

--- a/spec/httmultiparty_spec.rb
+++ b/spec/httmultiparty_spec.rb
@@ -20,6 +20,7 @@ describe HTTMultiParty do
   it "should extend HTTParty::Request::SupportedHTTPMethods with Multipart methods" do
     HTTParty::Request::SupportedHTTPMethods.should include HTTMultiParty::MultipartPost
     HTTParty::Request::SupportedHTTPMethods.should include HTTMultiParty::MultipartPut
+    HTTParty::Request::SupportedHTTPMethods.should include HTTMultiParty::MultipartPatch
   end
 
   describe '#hash_contains_files?' do
@@ -226,6 +227,34 @@ describe HTTMultiParty do
         content_types = result.map { |(k,v)| v.content_type  }
 
         content_types.should == ['image/jpeg', 'image/png']
+      end
+    end
+
+    describe "when :multipart is true" do
+      subject  { HTTMultiParty.query_string_normalizer(multipart: true) }
+
+      it "should map non-file parameters into key-value array pairs" do
+        result = subject.call({
+          :foo => 'foo value',
+          :bar => 'bar value'
+        })
+
+        result.should == [['foo', 'foo value'], ['bar', 'bar value']]
+        
+      end
+    end
+
+    describe "when :multipart is false" do
+      subject  { HTTMultiParty.query_string_normalizer(multipart: false) }
+
+      it "should map non-file parameters into key-value string pairs" do
+        result = subject.call({
+          :foo => 'foo value',
+          :bar => 'bar value'
+        })
+
+        result.should == ['foo=foo value', 'bar=bar value']
+        
       end
     end
   end


### PR DESCRIPTION
Adds support for PATCH requests with multipart/form body. Also introduces forcing "multipart" format for non-files parameters.